### PR TITLE
Add filename display in Excel editor header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import ExcelJS from "exceljs"
 function App() {
   const { toggleFullScreen } = useFullScreen()
   const [workbook, setWorkbook] = useState<ExcelJS.Workbook | null>(null)
+  const [fileName, setFileName] = useState<string | null>(null)
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -36,7 +37,11 @@ function App() {
       <FullScreenProvider>
         <ExcelEditor
           workbook={workbook}
-          onClose={() => setWorkbook(null)}
+          fileName={fileName ?? ""}
+          onClose={() => {
+            setWorkbook(null)
+            setFileName(null)
+          }}
         />
       </FullScreenProvider>
     )
@@ -45,7 +50,7 @@ function App() {
   return (
     <>
       <Header />
-      <DragDropArea setWorkbook={setWorkbook} />
+      <DragDropArea setWorkbook={setWorkbook} setFileName={setFileName} />
       <Footer />
     </>
   )

--- a/src/DragDropArea.tsx
+++ b/src/DragDropArea.tsx
@@ -8,9 +8,10 @@ import ExcelJS from "exceljs"
 
 interface DragDropAreaProps {
   setWorkbook: (workbook: ExcelJS.Workbook) => void
+  setFileName: (name: string) => void
 }
 
-const DragDropArea: React.FC<DragDropAreaProps> = ({ setWorkbook }) => {
+const DragDropArea: React.FC<DragDropAreaProps> = ({ setWorkbook, setFileName }) => {
   const [dragging, setDragging] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [loading, setLoading] = useState(false)
@@ -60,6 +61,7 @@ const DragDropArea: React.FC<DragDropAreaProps> = ({ setWorkbook }) => {
         })
       }
       setWorkbook(workbook)
+      setFileName(file.name)
     } catch (error) {
       alert(error instanceof Error ? error.message : error)
       console.error(error)
@@ -97,6 +99,7 @@ const DragDropArea: React.FC<DragDropAreaProps> = ({ setWorkbook }) => {
         })
       }
       setWorkbook(workbook)
+      setFileName(file.name)
     } catch (error) {
       alert(error instanceof Error ? error.message : error)
       console.error(error)

--- a/src/ExcelEditor.tsx
+++ b/src/ExcelEditor.tsx
@@ -7,10 +7,11 @@ import { twJoin } from "tailwind-merge"
 
 interface ExcelEditorProps {
   workbook: ExcelJS.Workbook
+  fileName: string
   onClose: () => void
 }
 
-const ExcelEditor: React.FC<ExcelEditorProps> = ({ workbook, onClose }) => {
+const ExcelEditor: React.FC<ExcelEditorProps> = ({ workbook, fileName, onClose }) => {
   const { isFullScreen, toggleFullScreen } = useFullScreen()
   const [darkMode, setDarkMode] = useState(getDarkmode())
   const [activeSheetIndex, setActiveSheetIndex] = useState(0)
@@ -64,6 +65,7 @@ const ExcelEditor: React.FC<ExcelEditorProps> = ({ workbook, onClose }) => {
         setDarkMode={setDarkMode}
         isFullScreen={isFullScreen}
         toggleFullScreen={toggleFullScreen}
+        fileName={fileName}
         onClose={onClose}
       />
       <div className="flex flex-col flex-1 overflow-hidden">

--- a/src/ExcelEditorHeader.tsx
+++ b/src/ExcelEditorHeader.tsx
@@ -14,6 +14,7 @@ interface ExcelEditorHeaderProps {
   isFullScreen: boolean
   toggleFullScreen: () => void
   onClose: () => void
+  fileName: string
 }
 
 const ExcelEditorHeader: React.FC<ExcelEditorHeaderProps> = ({
@@ -22,6 +23,7 @@ const ExcelEditorHeader: React.FC<ExcelEditorHeaderProps> = ({
   isFullScreen,
   toggleFullScreen,
   onClose,
+  fileName,
 }) => {
   const { t } = useTranslation()
 
@@ -46,6 +48,9 @@ const ExcelEditorHeader: React.FC<ExcelEditorHeaderProps> = ({
             className="transform -scale-x-100"
           />
         </Tooltip>
+      </div>
+      <div className="flex-1 overflow-hidden text-center text-sm font-medium text-black dark:text-white">
+        {fileName}
       </div>
       <div className="flex items-center space-x-2">
         <Tooltip text={t("others.toggleDarkMode")} place="bottom">


### PR DESCRIPTION
## Summary
- store uploaded file name in `App` state
- forward file name through `DragDropArea` and `ExcelEditor` to `ExcelEditorHeader`
- show the file name centered in the editor header

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68681e631f7c833386787bdb1820f1f0