### PR TITLE
Fix trailing blank row display

### DIFF
--- a/src/ExcelEditor.tsx
+++ b/src/ExcelEditor.tsx
@@ -52,7 +52,7 @@ const ExcelEditor: React.FC<ExcelEditorProps> = ({ workbook, fileName, onClose }
     let lastRowIdx = activeSheet.rowCount
     while (lastRowIdx > 0) {
       const row = activeSheet.getRow(lastRowIdx)
-      const hasData = row.values.some((v, idx) => {
+      const hasData = Array.isArray(row.values) && row.values.some((v, idx) => {
         if (idx === 0) return false
         return v !== null && v !== undefined && v !== ''
       })


### PR DESCRIPTION
## Summary
- only render rows up to the last non-empty row

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6869ea73f8f48333b7c60a23386cbbf7