### PR TITLE
Improve CSV parsing

### DIFF
--- a/src/DragDropArea.tsx
+++ b/src/DragDropArea.tsx
@@ -6,6 +6,7 @@ import { useMediaQuery } from "usehooks-ts"
 import SheetIcon from "./assets/icons/sheet.svg?react"
 import Spinner from "./Spinner"
 import { useDarkmode } from "./hooks/useDarkmode"
+import { parseCsv } from "./utils/parseCsv"
 
 interface DragDropAreaProps {
   setWorkbook: (workbook: ExcelJS.Workbook) => void
@@ -60,11 +61,9 @@ const DragDropArea: React.FC<DragDropAreaProps> = ({
         await workbook.xlsx.load(arrayBuffer)
       } else if (fileName.endsWith(".csv")) {
         const csvData = await file.text()
+        const rows = parseCsv(csvData)
         const worksheet = workbook.addWorksheet("Sheet1")
-        csvData.split("\n").forEach((row) => {
-          const values = row.split(",")
-          worksheet.addRow(values)
-        })
+        rows.forEach((r) => worksheet.addRow(r))
       }
       setWorkbook(workbook)
       setFileName(file.name)
@@ -99,11 +98,9 @@ const DragDropArea: React.FC<DragDropAreaProps> = ({
         await workbook.xlsx.load(arrayBuffer)
       } else if (fileName.endsWith(".csv")) {
         const csvData = await file.text()
+        const rows = parseCsv(csvData)
         const worksheet = workbook.addWorksheet("Sheet1")
-        csvData.split("\n").forEach((row) => {
-          const values = row.split(",")
-          worksheet.addRow(values)
-        })
+        rows.forEach((r) => worksheet.addRow(r))
       }
       setWorkbook(workbook)
       setFileName(file.name)

--- a/src/utils/parseCsv.ts
+++ b/src/utils/parseCsv.ts
@@ -1,0 +1,53 @@
+export function parseCsv(data: string): string[][] {
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ""
+  let inQuotes = false
+  for (let i = 0; i < data.length; i++) {
+    const char = data[i]
+    if (inQuotes) {
+      if (char === '"') {
+        if (data[i + 1] === '"') {
+          field += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        field += char
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true
+      } else if (char === ',') {
+        row.push(field)
+        field = ""
+      } else if (char === '\n') {
+        row.push(field)
+        rows.push(row)
+        row = []
+        field = ""
+      } else if (char === '\r') {
+        // handle CRLF or standalone CR
+        if (data[i + 1] === '\n') {
+          row.push(field)
+          rows.push(row)
+          row = []
+          field = ""
+          i++
+        } else {
+          row.push(field)
+          rows.push(row)
+          row = []
+          field = ""
+        }
+      } else {
+        field += char
+      }
+    }
+  }
+  // push last field
+  row.push(field)
+  rows.push(row)
+  return rows
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "types": ["./vite-env.d.ts"],
+    "types": ["./vite-env.d.ts", "node"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- parse CSVs properly instead of simple string splitting
- add small CSV parser
- include Node types for TS

## Testing
- `yarn build`
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_686adffc51808333836d23977d4eb429