### PR TITLE
Fix useMediaQuery in DragDropArea

### DIFF
--- a/src/DragDropArea.tsx
+++ b/src/DragDropArea.tsx
@@ -19,7 +19,7 @@ const DragDropArea: React.FC<DragDropAreaProps> = ({
   const [dragging, setDragging] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [loading, setLoading] = useState(false)
-  const smallScreen = useMediaQuery("(max-width: 640px) or (max-height: 640px)")
+  const smallScreen = useMediaQuery("(max-width: 640px), (max-height: 640px)")
   const { darkMode } = useDarkmode()
 
   const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary
- tweak the media query string so useMediaQuery handles width and height breakpoints properly

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_686adf9fe84c8333918776ba0a0d3135