### PR TITLE
Fix back button when viewing spreadsheet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,22 @@ function App() {
     }
   }, [toggleFullScreen])
 
+  useEffect(() => {
+    if (!workbook) return
+
+    const handlePopState = () => {
+      setWorkbook(null)
+      setFileName(null)
+    }
+
+    window.history.pushState({ excelOpen: true }, "")
+    window.addEventListener("popstate", handlePopState)
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState)
+    }
+  }, [workbook])
+
   if (workbook) {
     return (
       <FullScreenProvider>
@@ -41,6 +57,7 @@ function App() {
           onClose={() => {
             setWorkbook(null)
             setFileName(null)
+            window.history.back()
           }}
         />
       </FullScreenProvider>


### PR DESCRIPTION
## Summary
- intercept browser back navigation when a spreadsheet is open
- return to the app page when closing the editor

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686ee51a21208333b492381e70a80cce