### PR TITLE
Fix first row cell focus outline

### DIFF
--- a/src/ExcelCell.tsx
+++ b/src/ExcelCell.tsx
@@ -65,7 +65,7 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
       {editing && (
         <input
           ref={inputRef}
-          className="absolute left-0 top-0 right-0 bottom-0 px-[6px] py-[2px] box-border border-none bg-white dark:bg-neutral-900"
+          className="absolute left-0 top-0 right-0 bottom-0 px-[6px] py-[2px] box-border border-none bg-white dark:bg-neutral-900 focus:outline-pink-900 focus:outline-2 focus:[outline-offset:-2px] dark:focus:outline-pink-700"
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onBlur={handleBlur}


### PR DESCRIPTION
## Summary
- fix outline clipping for first row cells by adding negative outline offset

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686ff8392cf8833390f66f27f3a51749