### PR TITLE
fix: keep changes when reopening editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ function App() {
   const [workbook, setWorkbook] = useState<Workbook | null>(null)
   const [fileName, setFileName] = useState<string | null>(null)
   const [editorOpen, setEditorOpen] = useState(false)
+  const [hasChanges, setHasChanges] = useState(false)
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -42,6 +43,9 @@ function App() {
           onClose={() => {
             setEditorOpen(false)
           }}
+          onWorkbookChange={setWorkbook}
+          initialHasChanges={hasChanges}
+          onHasChangesChange={setHasChanges}
         />
       </FullScreenProvider>
     )
@@ -57,6 +61,7 @@ function App() {
         setWorkbook={setWorkbook}
         setFileName={setFileName}
         onOpenEditor={() => setEditorOpen(true)}
+        setHasChanges={setHasChanges}
       />
       <Footer />
     </>

--- a/src/DragDropArea.tsx
+++ b/src/DragDropArea.tsx
@@ -13,12 +13,14 @@ interface DragDropAreaProps {
   setWorkbook: (workbook: Workbook) => void
   setFileName: (name: string) => void
   onOpenEditor: () => void
+  setHasChanges: (changes: boolean) => void
 }
 
 const DragDropArea: React.FC<DragDropAreaProps> = ({
   setWorkbook,
   setFileName,
   onOpenEditor,
+  setHasChanges,
 }) => {
   const [dragging, setDragging] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -69,6 +71,7 @@ const DragDropArea: React.FC<DragDropAreaProps> = ({
       }
       setWorkbook(workbook)
       setFileName(file.name)
+      setHasChanges(false)
       onOpenEditor()
     } catch (error) {
       alert(error instanceof Error ? error.message : error)
@@ -106,6 +109,7 @@ const DragDropArea: React.FC<DragDropAreaProps> = ({
       }
       setWorkbook(workbook)
       setFileName(file.name)
+      setHasChanges(false)
       onOpenEditor()
     } catch (error) {
       alert(error instanceof Error ? error.message : error)

--- a/src/ExcelEditor.tsx
+++ b/src/ExcelEditor.tsx
@@ -9,18 +9,32 @@ interface ExcelEditorProps {
   workbook: Workbook
   fileName: string
   onClose: () => void
+  onWorkbookChange?: (workbook: Workbook) => void
+  initialHasChanges?: boolean
+  onHasChangesChange?: (hasChanges: boolean) => void
 }
 
 const ExcelEditor: React.FC<ExcelEditorProps> = ({
   workbook,
   fileName,
   onClose,
+  onWorkbookChange,
+  initialHasChanges = false,
+  onHasChangesChange,
 }) => {
   const { isFullScreen, toggleFullScreen } = useFullScreen()
   const [activeSheetIndex, setActiveSheetIndex] = useState(0)
   const [worksheets, setWorksheets] = useState<Worksheet[]>(workbook.worksheets)
-  const [hasChanges, setHasChanges] = useState(false)
+  const [hasChanges, setHasChanges] = useState(initialHasChanges)
   const activeSheet = worksheets[activeSheetIndex]
+
+  useEffect(() => {
+    setWorksheets(workbook.worksheets)
+  }, [workbook])
+
+  useEffect(() => {
+    setHasChanges(initialHasChanges)
+  }, [initialHasChanges])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -80,9 +94,11 @@ const ExcelEditor: React.FC<ExcelEditorProps> = ({
       data[r][c] = cell
       sheet.data = data
       copy[activeSheetIndex] = sheet
+      onWorkbookChange?.({ worksheets: copy })
       return copy
     })
     setHasChanges(true)
+    onHasChangesChange?.(true)
   }
 
   const rows = Array.from({ length: rowCount }).map((_, rIdx) => {
@@ -110,6 +126,7 @@ const ExcelEditor: React.FC<ExcelEditorProps> = ({
     })
     writeFile(wb, fileName)
     setHasChanges(false)
+    onHasChangesChange?.(false)
   }
 
   return (


### PR DESCRIPTION
## Summary
- persist workbook state and unsaved change flag in the app
- sync workbook and change state between `ExcelEditor` and `App`
- reset change flag when loading a file

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687007af5db48333a193f4ff214fcc9d