### PR TITLE
Fix leading cell offsets

### DIFF
--- a/src/ExcelEditor.tsx
+++ b/src/ExcelEditor.tsx
@@ -114,6 +114,12 @@ const ExcelEditor: React.FC<ExcelEditorProps> = ({
     worksheets.forEach((ws) => {
       const aoa = ws.data.map((row) => row.map((c) => c?.v ?? null))
       const sheet = utils.aoa_to_sheet(aoa)
+      const rowCount = ws.data.length
+      const colCount = ws.data.reduce((m, r) => Math.max(m, r.length), 0)
+      sheet['!ref'] = utils.encode_range({
+        s: { r: 0, c: 0 },
+        e: { r: rowCount - 1, c: colCount - 1 },
+      })
       ws.data.forEach((row, r) => {
         row.forEach((cell, c) => {
           if (cell?.f) {


### PR DESCRIPTION
## Summary
- preserve rows/columns before the first used cell when loading spreadsheets
- keep the preserved range when exporting

## Testing
- `yarn lint` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_68701f5ad95883338569b4ba22585981