### PR TITLE
Align numeric cells right and parse on commit

### DIFF
--- a/src/ExcelCell.tsx
+++ b/src/ExcelCell.tsx
@@ -38,12 +38,16 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
       if (!copy[rowIndex]) copy[rowIndex] = []
       copy[rowIndex][colIndex] = { v: null, f: formula }
       const result = evaluateFormula(copy, rowIndex, colIndex)
-      onChange(rowIndex, colIndex, { v: result, f: formula })
+      const type = typeof result === "number" ? "n" : typeof result === "boolean" ? "b" : "s"
+      onChange(rowIndex, colIndex, { v: result, f: formula, t: type })
     } else {
       const trimmed = val.trim()
       const num = Number(trimmed)
-      const value = trimmed !== "" && !Number.isNaN(num) ? num : val
-      onChange(rowIndex, colIndex, { v: value })
+      if (trimmed !== "" && !Number.isNaN(num)) {
+        onChange(rowIndex, colIndex, { v: num, t: "n" })
+      } else {
+        onChange(rowIndex, colIndex, { v: val, t: "s" })
+      }
     }
   }
 
@@ -70,7 +74,7 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
       className={twMerge(
         "px-2 py-1 text-black dark:text-white border border-gray-300 dark:border-neutral-600 relative",
         rowIndex === 0 && "border-t-0",
-        typeof cell?.v === "number" && "text-right"
+        cell?.t === "n" && "text-right"
       )}
       onClick={() => setEditing(true)}
     >
@@ -79,7 +83,7 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
           ref={inputRef}
           className={twMerge(
             "absolute left-0 top-0 right-0 bottom-0 px-2 py-1 box-border border-none bg-white dark:bg-neutral-900 focus:outline-pink-900 focus:outline-2 focus:[outline-offset:-2px] dark:focus:outline-pink-700",
-            typeof cell?.v === "number" && "text-right"
+            cell?.t === "n" && "text-right"
           )}
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}

--- a/src/ExcelCell.tsx
+++ b/src/ExcelCell.tsx
@@ -40,7 +40,10 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
       const result = evaluateFormula(copy, rowIndex, colIndex)
       onChange(rowIndex, colIndex, { v: result, f: formula })
     } else {
-      onChange(rowIndex, colIndex, { v: val })
+      const trimmed = val.trim()
+      const num = Number(trimmed)
+      const value = trimmed !== "" && !Number.isNaN(num) ? num : val
+      onChange(rowIndex, colIndex, { v: value })
     }
   }
 
@@ -66,14 +69,18 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
     <td
       className={twMerge(
         "px-2 py-1 text-black dark:text-white border border-gray-300 dark:border-neutral-600 relative",
-        rowIndex === 0 && "border-t-0"
+        rowIndex === 0 && "border-t-0",
+        typeof cell?.v === "number" && "text-right"
       )}
       onClick={() => setEditing(true)}
     >
       {editing && (
         <input
           ref={inputRef}
-          className="absolute left-0 top-0 right-0 bottom-0 px-2 py-1 box-border border-none bg-white dark:bg-neutral-900 focus:outline-pink-900 focus:outline-2 focus:[outline-offset:-2px] dark:focus:outline-pink-700"
+          className={twMerge(
+            "absolute left-0 top-0 right-0 bottom-0 px-2 py-1 box-border border-none bg-white dark:bg-neutral-900 focus:outline-pink-900 focus:outline-2 focus:[outline-offset:-2px] dark:focus:outline-pink-700",
+            typeof cell?.v === "number" && "text-right"
+          )}
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onBlur={handleBlur}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface Cell {
   v: string | number | boolean | null
   f?: string
+  t?: 'n' | 's' | 'b' | 'd'
 }
 
 export interface Worksheet {

--- a/src/utils/parseCsv.ts
+++ b/src/utils/parseCsv.ts
@@ -22,23 +22,23 @@ export function parseCsv(data: string): Cell[][] {
       if (char === '"') {
         inQuotes = true
       } else if (char === ',') {
-        row.push({ v: field })
+        row.push({ v: field, t: 's' })
         field = ""
       } else if (char === '\n') {
-        row.push({ v: field })
+        row.push({ v: field, t: 's' })
         rows.push(row)
         row = []
         field = ""
       } else if (char === '\r') {
         // handle CRLF or standalone CR
         if (data[i + 1] === '\n') {
-          row.push({ v: field })
+          row.push({ v: field, t: 's' })
           rows.push(row)
           row = []
           field = ""
           i++
         } else {
-          row.push({ v: field })
+          row.push({ v: field, t: 's' })
           rows.push(row)
           row = []
           field = ""
@@ -49,7 +49,7 @@ export function parseCsv(data: string): Cell[][] {
     }
   }
   // push last field
-  row.push({ v: field })
+  row.push({ v: field, t: 's' })
   rows.push(row)
   return rows
 }

--- a/src/utils/readSpreadsheet.ts
+++ b/src/utils/readSpreadsheet.ts
@@ -17,12 +17,15 @@ export async function readSpreadsheet(buffer: ArrayBuffer): Promise<Workbook> {
       for (let C = range.s.c; C <= range.e.c; C++) {
         const addr = utils.encode_cell({ r: R, c: C })
         const cell = ws[addr] as
-          | { v?: string | number | boolean; f?: string }
+          | { v?: string | number | boolean; f?: string; t?: string }
           | undefined
         if (cell) {
           const value = cell.v ?? null
           const formula = cell.f as string | undefined
-          data[R][C] = formula ? { v: value, f: formula } : { v: value }
+          const type = cell.t as Cell['t'] | undefined
+          const cellData: Cell = formula ? { v: value, f: formula } : { v: value }
+          if (type) cellData.t = type
+          data[R][C] = cellData
         }
       }
     }


### PR DESCRIPTION
## Summary
- align number values to the right in the spreadsheet
- store edited numeric strings as numbers

## Testing
- `yarn lint src/ExcelCell.tsx`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68703ad11ee483339bc99d159f6143d4