### PR TITLE
Fix React setState during render

### DIFF
--- a/src/ExcelEditor.tsx
+++ b/src/ExcelEditor.tsx
@@ -86,17 +86,17 @@ const ExcelEditor: React.FC<ExcelEditorProps> = ({
   const colCount = getLastNonEmptyCol()
 
   const updateCell = (r: number, c: number, cell: Cell) => {
-    setWorksheets((prev) => {
-      const copy = [...prev]
-      const sheet = { ...copy[activeSheetIndex] }
-      const data = sheet.data.map((row) => [...row])
-      if (!data[r]) data[r] = []
-      data[r][c] = cell
-      sheet.data = data
-      copy[activeSheetIndex] = sheet
-      onWorkbookChange?.({ worksheets: copy })
-      return copy
-    })
+    const nextWorksheets = [...worksheets]
+    const sheet = { ...nextWorksheets[activeSheetIndex] }
+    const data = sheet.data.map((row) => [...row])
+    if (!data[r]) data[r] = []
+    data[r][c] = cell
+    sheet.data = data
+    nextWorksheets[activeSheetIndex] = sheet
+
+    setWorksheets(nextWorksheets)
+    onWorkbookChange?.({ worksheets: nextWorksheets })
+
     setHasChanges(true)
     onHasChangesChange?.(true)
   }


### PR DESCRIPTION
## Summary
- avoid calling parent's state setter from within a state update in `ExcelEditor`

## Testing
- `yarn run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870451b37608333b0b5242fe3b9f659