### PR TITLE
Enhance download icon thickness

### DIFF
--- a/src/DownloadIcon.tsx
+++ b/src/DownloadIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+
+const DownloadIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={2}
+    stroke="currentColor"
+    aria-hidden="true"
+    data-slot="icon"
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
+    />
+  </svg>
+)
+
+export default DownloadIcon

--- a/src/ExcelHeader.tsx
+++ b/src/ExcelHeader.tsx
@@ -5,7 +5,7 @@ import CompressIcon from "./assets/icons/compress.svg?react"
 import XmarkIcon from "./assets/icons/xmark.svg?react"
 import IconButton from "./IconButton"
 import Tooltip from "./Tooltip"
-import { ArrowDownTrayIcon } from "@heroicons/react/24/solid"
+import DownloadIcon from "./DownloadIcon"
 import { useDarkmode } from "./hooks/useDarkmode"
 import ExcelDarkModeToggleIcon from "./ExcelDarkModeToggleIcon"
 
@@ -71,7 +71,7 @@ const ExcelHeader: React.FC<ExcelHeaderProps> = ({
       <div className="flex items-center space-x-2">
         {hasChanges && (
           <Tooltip text={t("others.download")} place="bottom" className="rounded-full animate-bounce hover:animate-none">
-            <IconButton svgIcon={ArrowDownTrayIcon} onClick={onDownload} />
+            <IconButton svgIcon={DownloadIcon} onClick={onDownload} />
           </Tooltip>
         )}
         <Tooltip text={t("others.toggleDarkMode")} place="bottom" className="rounded-full">


### PR DESCRIPTION
## Summary
- create custom `DownloadIcon` with thicker strokes
- replace `ArrowDownTrayIcon` usage in `ExcelHeader`

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68711bf26c008333a34bc1f32232d64f