### PR TITLE
Implement tab navigation between cells

### DIFF
--- a/src/ExcelCell.tsx
+++ b/src/ExcelCell.tsx
@@ -61,6 +61,20 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
       e.stopPropagation()
       setEditing(false)
       setInputValue("")
+    } else if (e.key === "Tab") {
+      e.preventDefault()
+      commit()
+      setEditing(false)
+      const td = inputRef.current?.closest("td") as HTMLTableCellElement | null
+      if (!td) return
+      let next: HTMLTableCellElement | null = td.nextElementSibling as
+        | HTMLTableCellElement
+        | null
+      if (!next) {
+        const nextRow = td.parentElement?.nextElementSibling as HTMLTableRowElement | null
+        next = nextRow?.querySelector("td") || null
+      }
+      next?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
     }
   }
 


### PR DESCRIPTION
## Summary
- allow tab key to move focus to the next cell

## Testing
- `yarn lint` *(fails: mise warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687143511a4c8333a88320f2f1f96feb