### PR TITLE
Fix ExcelCell memoization

### DIFF
--- a/src/ExcelCell.tsx
+++ b/src/ExcelCell.tsx
@@ -128,9 +128,7 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
   )
 }
 
-export default ExcelCell
-
-// export default React.memo(
-//   ExcelCell,
-//   (prev, next) => prev.cell === next.cell,
-// )
+export default React.memo(
+  ExcelCell,
+  (prev, next) => prev.cell === next.cell,
+)

--- a/src/ExcelEditor.tsx
+++ b/src/ExcelEditor.tsx
@@ -165,26 +165,27 @@ const ExcelEditor: React.FC<ExcelEditorProps> = ({
 
   const colCount = getLastNonEmptyCol()
 
-  const updateCell = (
-    r: number,
-    c: number,
-    cell: Partial<CellObject>,
-  ) => {
-    const copy = [...sheets]
-    const sheet = { ...copy[activeSheetIndex] }
-    const data = [...sheet.data]
-    const row = [...(data[r] || [])]
-    row[c] = cell
-    data[r] = row
-    sheet.data = data
-    copy[activeSheetIndex] = sheet
-    const sheetName = workbook.SheetNames[activeSheetIndex]
-    dataToSheet(sheet.data, workbook.Sheets[sheetName])
-    onWorkbookChange?.(workbook)
-    setSheets(copy)
-    setHasChanges(true)
-    onHasChangesChange?.(true)
-  }
+  const updateCell = useCallback(
+    (r: number, c: number, cell: Partial<CellObject>) => {
+      setSheets((prev) => {
+        const copy = [...prev]
+        const sheet = { ...copy[activeSheetIndex] }
+        const data = [...sheet.data]
+        const row = [...(data[r] || [])]
+        row[c] = cell
+        data[r] = row
+        sheet.data = data
+        copy[activeSheetIndex] = sheet
+        const sheetName = workbook.SheetNames[activeSheetIndex]
+        dataToSheet(sheet.data, workbook.Sheets[sheetName])
+        onWorkbookChange?.(workbook)
+        return copy
+      })
+      setHasChanges(true)
+      onHasChangesChange?.(true)
+    },
+    [activeSheetIndex, workbook, onWorkbookChange, onHasChangesChange],
+  )
 
   const rows = Array.from({ length: rowCount }).map((_, rIdx) => {
     const rowData = activeSheet.data[rIdx] || []


### PR DESCRIPTION
## Summary
- memoize `ExcelCell` again to avoid unnecessary re-renders
- stabilize `updateCell` with `useCallback` to keep closures fresh

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6872a0bc62ac8333b09419d66c56cf00