### PR TITLE
Add image hover preview

### DIFF
--- a/src/ExcelCell.tsx
+++ b/src/ExcelCell.tsx
@@ -177,7 +177,7 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
   return (
     <td
       className={twMerge(
-        "min-w-12 px-2 py-1 text-black dark:text-white border border-gray-300 dark:border-neutral-600 relative",
+        "min-w-12 px-2 py-1 text-black dark:text-white border border-gray-300 dark:border-neutral-600 relative cursor-default",
         rowIndex === 0 && "border-t-0",
         cell?.t === "n" && !editing && "text-right"
       )}

--- a/src/ExcelCell.tsx
+++ b/src/ExcelCell.tsx
@@ -1,10 +1,22 @@
 import React, { useEffect, useRef, useState } from "react"
 import { twMerge } from "tailwind-merge"
+import ImagePreview from "./ImagePreview"
 import type { CellObject } from "xlsx"
 import { HyperFormula } from "hyperformula"
 import { formatDate } from "./utils/date"
 
 const FUNCTION_NAMES = HyperFormula.getRegisteredFunctionNames("enGB").sort()
+
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg)$/i
+
+const isImageUrl = (val: string): boolean => {
+  try {
+    const u = new URL(val)
+    return IMAGE_EXT_RE.test(u.pathname)
+  } catch {
+    return false
+  }
+}
 
 interface ExcelCellProps {
   rowIndex: number
@@ -159,6 +171,9 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
     }
   }
 
+  const displayValue = getDisplayValue(cell)
+  const showImagePreview = !editing && isImageUrl(displayValue)
+
   return (
     <td
       className={twMerge(
@@ -187,7 +202,11 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
           )}
         </div>
       )}
-      {getDisplayValue(cell)}
+      {showImagePreview ? (
+        <ImagePreview url={displayValue}>{displayValue}</ImagePreview>
+      ) : (
+        displayValue
+      )}
     </td>
   )
 }

--- a/src/ImagePreview.tsx
+++ b/src/ImagePreview.tsx
@@ -53,7 +53,7 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 300, children 
       {show && (
         <div
           className={twJoin(
-            "absolute left-1/2 z-20 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800",
+            "absolute left-1/2 z-20 -translate-x-1/2 rounded-md border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800",
             showAbove ? "bottom-full mb-2" : "top-full mt-2",
             imageLoaded ? "block" : "hidden",
           )}
@@ -61,7 +61,7 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 300, children 
           <img
             src={url}
             alt="preview"
-            className="max-h-64 max-w-[16rem] object-contain"
+            className="max-h-64 max-w-[16rem] object-contain rounded-sm"
             onLoad={handleImageLoad}
             onError={handleImageError}
           />

--- a/src/ImagePreview.tsx
+++ b/src/ImagePreview.tsx
@@ -9,6 +9,7 @@ interface ImagePreviewProps {
 const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children }) => {
   const [show, setShow] = useState(false)
   const [showAbove, setShowAbove] = useState(false)
+  const [imageLoaded, setImageLoaded] = useState(false)
   const timerRef = useRef<number | null>(null)
   const containerRef = useRef<HTMLSpanElement>(null)
 
@@ -28,6 +29,15 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children 
       timerRef.current = null
     }
     setShow(false)
+    setImageLoaded(false)
+  }
+
+  const handleImageLoad = () => {
+    setImageLoaded(true)
+  }
+
+  const handleImageError = () => {
+    setImageLoaded(false)
   }
 
   return (
@@ -43,12 +53,19 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children 
           className={
             showAbove
               ?
-                "absolute left-1/2 bottom-full z-20 mb-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800"
+              "absolute left-1/2 bottom-full z-20 mb-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800"
               :
-                "absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800"
+              "absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800"
           }
+          style={{ display: imageLoaded ? 'block' : 'none' }}
         >
-          <img src={url} alt="preview" className="max-h-64 max-w-[16rem] object-contain" />
+          <img
+            src={url}
+            alt="preview"
+            className="max-h-64 max-w-[16rem] object-contain"
+            onLoad={handleImageLoad}
+            onError={handleImageError}
+          />
         </div>
       )}
     </span>

--- a/src/ImagePreview.tsx
+++ b/src/ImagePreview.tsx
@@ -1,0 +1,37 @@
+import React, { useRef, useState } from "react"
+
+interface ImagePreviewProps {
+  url: string
+  delay?: number
+  children: React.ReactNode
+}
+
+const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children }) => {
+  const [show, setShow] = useState(false)
+  const timerRef = useRef<number | null>(null)
+
+  const handleMouseEnter = () => {
+    timerRef.current = window.setTimeout(() => setShow(true), delay)
+  }
+
+  const handleMouseLeave = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    setShow(false)
+  }
+
+  return (
+    <span className="relative" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+      {children}
+      {show && (
+        <div className="absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800">
+          <img src={url} alt="preview" className="max-h-64 max-w-[16rem] object-contain" />
+        </div>
+      )}
+    </span>
+  )
+}
+
+export default ImagePreview

--- a/src/ImagePreview.tsx
+++ b/src/ImagePreview.tsx
@@ -7,7 +7,7 @@ interface ImagePreviewProps {
   children: React.ReactNode
 }
 
-const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children }) => {
+const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 300, children }) => {
   const [show, setShow] = useState(false)
   const [showAbove, setShowAbove] = useState(false)
   const [imageLoaded, setImageLoaded] = useState(false)

--- a/src/ImagePreview.tsx
+++ b/src/ImagePreview.tsx
@@ -8,10 +8,18 @@ interface ImagePreviewProps {
 
 const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children }) => {
   const [show, setShow] = useState(false)
+  const [showAbove, setShowAbove] = useState(false)
   const timerRef = useRef<number | null>(null)
+  const containerRef = useRef<HTMLSpanElement>(null)
 
   const handleMouseEnter = () => {
-    timerRef.current = window.setTimeout(() => setShow(true), delay)
+    timerRef.current = window.setTimeout(() => {
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect()
+        setShowAbove(rect.top > window.innerHeight / 2)
+      }
+      setShow(true)
+    }, delay)
   }
 
   const handleMouseLeave = () => {
@@ -23,10 +31,23 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children 
   }
 
   return (
-    <span className="relative" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+    <span
+      ref={containerRef}
+      className="relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       {children}
       {show && (
-        <div className="absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800">
+        <div
+          className={
+            showAbove
+              ?
+                "absolute left-1/2 bottom-full z-20 mb-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800"
+              :
+                "absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800"
+          }
+        >
           <img src={url} alt="preview" className="max-h-64 max-w-[16rem] object-contain" />
         </div>
       )}

--- a/src/ImagePreview.tsx
+++ b/src/ImagePreview.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from "react"
+import { twJoin } from "tailwind-merge"
 
 interface ImagePreviewProps {
   url: string
@@ -20,6 +21,7 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children 
         setShowAbove(rect.top > window.innerHeight / 2)
       }
       setShow(true)
+      setImageLoaded(false)
     }, delay)
   }
 
@@ -50,14 +52,11 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 500, children 
       {children}
       {show && (
         <div
-          className={
-            showAbove
-              ?
-              "absolute left-1/2 bottom-full z-20 mb-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800"
-              :
-              "absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800"
-          }
-          style={{ display: imageLoaded ? 'block' : 'none' }}
+          className={twJoin(
+            "absolute left-1/2 z-20 -translate-x-1/2 rounded border border-gray-300 bg-white p-1 shadow-lg dark:border-neutral-600 dark:bg-neutral-800",
+            showAbove ? "bottom-full mb-2" : "top-full mt-2",
+            imageLoaded ? "block" : "hidden",
+          )}
         >
           <img
             src={url}


### PR DESCRIPTION
## Summary
- add new `ImagePreview` component
- show floating image preview when hovering an image URL in a cell

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_688031aef0c88333986beb698900f441