### PR TITLE
Add smart link preview

### DIFF
--- a/src/ExcelCell.tsx
+++ b/src/ExcelCell.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react"
 import { twMerge } from "tailwind-merge"
 import ImagePreview from "./ImagePreview"
+import LinkPreview from "./LinkPreview"
 import type { CellObject } from "xlsx"
 import { HyperFormula } from "hyperformula"
 import { formatDate } from "./utils/date"
@@ -13,6 +14,15 @@ const isImageUrl = (val: string): boolean => {
   try {
     const u = new URL(val)
     return IMAGE_EXT_RE.test(u.pathname)
+  } catch {
+    return false
+  }
+}
+
+const isHttpUrl = (val: string): boolean => {
+  try {
+    const u = new URL(val)
+    return u.protocol === "http:" || u.protocol === "https:"
   } catch {
     return false
   }
@@ -173,6 +183,8 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
 
   const displayValue = getDisplayValue(cell)
   const showImagePreview = !editing && isImageUrl(displayValue)
+  const showLinkPreview =
+    !editing && !showImagePreview && isHttpUrl(displayValue)
 
   return (
     <td
@@ -204,6 +216,8 @@ const ExcelCell: React.FC<ExcelCellProps> = ({
       )}
       {showImagePreview ? (
         <ImagePreview url={displayValue}>{displayValue}</ImagePreview>
+      ) : showLinkPreview ? (
+        <LinkPreview url={displayValue}>{displayValue}</LinkPreview>
       ) : (
         displayValue
       )}

--- a/src/ImagePreview.tsx
+++ b/src/ImagePreview.tsx
@@ -61,7 +61,7 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 300, children 
           <img
             src={url}
             alt="preview"
-            className="max-h-64 max-w-[16rem] object-contain rounded-sm"
+            className="max-h-64 max-w-64 object-contain rounded-sm"
             onLoad={handleImageLoad}
             onError={handleImageError}
           />

--- a/src/LinkPreview.tsx
+++ b/src/LinkPreview.tsx
@@ -23,20 +23,6 @@ const fetchYouTube = async (url: string): Promise<Metadata> => {
   return { title: data.title as string, thumbnail: data.thumbnail_url as string }
 }
 
-const fetchFigma = async (url: string): Promise<Metadata> => {
-  const res = await fetch(`https://www.figma.com/api/oembed?url=${encodeURIComponent(url)}`)
-  if (!res.ok) throw new Error("oembed failed")
-  const data = await res.json()
-  return { title: data.title as string, lastModified: data.last_modified as string }
-}
-
-const fetchTwitter = async (url: string): Promise<Metadata> => {
-  const res = await fetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}`)
-  if (!res.ok) throw new Error("noembed failed")
-  const data = await res.json()
-  return { title: data.title as string, author: data.author_name as string }
-}
-
 const fetchGeneric = async (url: string): Promise<Metadata> => {
   const res = await fetch(url)
   const text = await res.text()
@@ -58,10 +44,6 @@ const LinkPreview: React.FC<LinkPreviewProps> = ({ url, delay = 300, children })
       setLoading(true)
       if (u.hostname.includes("youtube.com") || u.hostname.includes("youtu.be")) {
         setMetadata(await fetchYouTube(url))
-      } else if (u.hostname.includes("figma.com")) {
-        setMetadata(await fetchFigma(url))
-      } else if (u.hostname.includes("twitter.com") || u.hostname.includes("x.com")) {
-        setMetadata(await fetchTwitter(url))
       } else {
         setMetadata(await fetchGeneric(url))
       }

--- a/src/LinkPreview.tsx
+++ b/src/LinkPreview.tsx
@@ -93,7 +93,7 @@ const LinkPreview: React.FC<LinkPreviewProps> = ({ url, delay = 300, children })
             showAbove ? "bottom-full mb-2" : "top-full mt-2",
           )}
         >
-          {loading && <Spinner />}
+          {loading && <Spinner size="small" />}
           {metadata && (
             <div className="flex flex-col gap-2">
               {metadata.title && (

--- a/src/LinkPreview.tsx
+++ b/src/LinkPreview.tsx
@@ -1,0 +1,147 @@
+import React, { useRef, useState, useEffect, useCallback } from "react"
+import { twJoin } from "tailwind-merge"
+import Spinner from "./Spinner"
+
+interface LinkPreviewProps {
+  url: string
+  delay?: number
+  children: React.ReactNode
+}
+
+interface Metadata {
+  title?: string
+  thumbnail?: string
+  author?: string
+  text?: string
+  lastModified?: string
+}
+
+const fetchYouTube = async (url: string): Promise<Metadata> => {
+  const res = await fetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}`)
+  if (!res.ok) throw new Error("noembed failed")
+  const data = await res.json()
+  return { title: data.title as string, thumbnail: data.thumbnail_url as string }
+}
+
+const fetchFigma = async (url: string): Promise<Metadata> => {
+  const res = await fetch(`https://www.figma.com/api/oembed?url=${encodeURIComponent(url)}`)
+  if (!res.ok) throw new Error("oembed failed")
+  const data = await res.json()
+  return { title: data.title as string, lastModified: data.last_modified as string }
+}
+
+const fetchTwitter = async (url: string): Promise<Metadata> => {
+  const res = await fetch(`https://noembed.com/embed?url=${encodeURIComponent(url)}`)
+  if (!res.ok) throw new Error("noembed failed")
+  const data = await res.json()
+  return { title: data.title as string, author: data.author_name as string }
+}
+
+const fetchGeneric = async (url: string): Promise<Metadata> => {
+  const res = await fetch(url)
+  const text = await res.text()
+  const match = text.match(/<title>(.*?)<\/title>/i)
+  return { title: match ? match[1] : url }
+}
+
+const LinkPreview: React.FC<LinkPreviewProps> = ({ url, delay = 300, children }) => {
+  const [show, setShow] = useState(false)
+  const [showAbove, setShowAbove] = useState(false)
+  const [metadata, setMetadata] = useState<Metadata | null>(null)
+  const [loading, setLoading] = useState(false)
+  const timerRef = useRef<number | null>(null)
+  const containerRef = useRef<HTMLSpanElement>(null)
+
+  const loadMetadata = useCallback(async () => {
+    try {
+      const u = new URL(url)
+      setLoading(true)
+      if (u.hostname.includes("youtube.com") || u.hostname.includes("youtu.be")) {
+        setMetadata(await fetchYouTube(url))
+      } else if (u.hostname.includes("figma.com")) {
+        setMetadata(await fetchFigma(url))
+      } else if (u.hostname.includes("twitter.com") || u.hostname.includes("x.com")) {
+        setMetadata(await fetchTwitter(url))
+      } else {
+        setMetadata(await fetchGeneric(url))
+      }
+    } catch {
+      setMetadata(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [url])
+
+  useEffect(() => {
+    if (show && !metadata && !loading) {
+      loadMetadata()
+    }
+  }, [show, metadata, loading, loadMetadata])
+
+  const handleMouseEnter = () => {
+    timerRef.current = window.setTimeout(() => {
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect()
+        setShowAbove(rect.top > window.innerHeight / 2)
+      }
+      setShow(true)
+    }, delay)
+  }
+
+  const handleMouseLeave = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    setShow(false)
+  }
+
+  return (
+    <span
+      ref={containerRef}
+      className="relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+      {show && (
+        <div
+          className={twJoin(
+            "absolute left-1/2 z-20 -translate-x-1/2 rounded-md border border-gray-300 bg-white p-2 shadow-lg dark:border-neutral-600 dark:bg-neutral-800 text-xs",
+            showAbove ? "bottom-full mb-2" : "top-full mt-2",
+          )}
+          style={{ width: "16rem" }}
+        >
+          {loading && <Spinner />}
+          {metadata && (
+            <div className="flex gap-2">
+              {metadata.thumbnail && (
+                <img
+                  src={metadata.thumbnail}
+                  alt="thumbnail"
+                  className="h-16 w-16 flex-shrink-0 object-cover rounded"
+                />
+              )}
+              <div className="space-y-1 overflow-hidden">
+                {metadata.title && (
+                  <div className="font-bold truncate" title={metadata.title}>
+                    {metadata.title}
+                  </div>
+                )}
+                {metadata.author && (
+                  <div className="text-gray-500">{metadata.author}</div>
+                )}
+                {metadata.text && <div className="line-clamp-3">{metadata.text}</div>}
+                {metadata.lastModified && (
+                  <div className="text-gray-500">Last modified {metadata.lastModified}</div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </span>
+  )
+}
+
+export default LinkPreview

--- a/src/LinkPreview.tsx
+++ b/src/LinkPreview.tsx
@@ -89,7 +89,7 @@ const LinkPreview: React.FC<LinkPreviewProps> = ({ url, delay = 300, children })
       {show && (
         <div
           className={twJoin(
-            "absolute max-w-64 left-1/2 z-20 -translate-x-1/2 rounded-md border border-gray-300 bg-white p-2 shadow-lg dark:border-neutral-600 dark:bg-neutral-800 text-xs",
+            "absolute max-w-64 left-1/2 z-20 -translate-x-1/2 rounded-md border border-gray-300 bg-white p-2 shadow-lg dark:border-neutral-600 dark:bg-neutral-800 text-xs transition-all",
             showAbove ? "bottom-full mb-2" : "top-full mt-2",
           )}
         >

--- a/src/LinkPreview.tsx
+++ b/src/LinkPreview.tsx
@@ -89,35 +89,25 @@ const LinkPreview: React.FC<LinkPreviewProps> = ({ url, delay = 300, children })
       {show && (
         <div
           className={twJoin(
-            "absolute left-1/2 z-20 -translate-x-1/2 rounded-md border border-gray-300 bg-white p-2 shadow-lg dark:border-neutral-600 dark:bg-neutral-800 text-xs",
+            "absolute max-w-64 left-1/2 z-20 -translate-x-1/2 rounded-md border border-gray-300 bg-white p-2 shadow-lg dark:border-neutral-600 dark:bg-neutral-800 text-xs",
             showAbove ? "bottom-full mb-2" : "top-full mt-2",
           )}
-          style={{ width: "16rem" }}
         >
           {loading && <Spinner />}
           {metadata && (
-            <div className="flex gap-2">
+            <div className="flex flex-col gap-2">
+              {metadata.title && (
+                <div className="font-bold truncate" title={metadata.title}>
+                  {metadata.title}
+                </div>
+              )}
               {metadata.thumbnail && (
                 <img
                   src={metadata.thumbnail}
                   alt="thumbnail"
-                  className="h-16 w-16 flex-shrink-0 object-cover rounded"
+                  className="object-cover rounded"
                 />
               )}
-              <div className="space-y-1 overflow-hidden">
-                {metadata.title && (
-                  <div className="font-bold truncate" title={metadata.title}>
-                    {metadata.title}
-                  </div>
-                )}
-                {metadata.author && (
-                  <div className="text-gray-500">{metadata.author}</div>
-                )}
-                {metadata.text && <div className="line-clamp-3">{metadata.text}</div>}
-                {metadata.lastModified && (
-                  <div className="text-gray-500">Last modified {metadata.lastModified}</div>
-                )}
-              </div>
             </div>
           )}
         </div>

--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -1,12 +1,21 @@
 import React from "react"
-import { twJoin } from "tailwind-merge"
+import { twMerge } from "tailwind-merge"
 
-const Spinner: React.FC = () => {
+interface SpinnerProps {
+  size?: "small" | "medium" | "large"
+  className?: string
+}
+
+const Spinner: React.FC<SpinnerProps> = ({ size = "large", className }) => {
   return (
     <div className="flex items-center justify-center">
       <div
-        className={twJoin(
-          "inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-gray-300 border-r-transparent align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite]",
+        className={twMerge(
+          "inline-block animate-spin rounded-full border-solid border-gray-300 border-r-transparent align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite]",
+          size === "small" && "size-4 border-2",
+          size === "medium" && "size-6 border-3",
+          size === "large" && "size-8 border-4",
+          className
         )}
         role="status"
       >


### PR DESCRIPTION
## Summary
- show floating link previews on hover
- implement `LinkPreview` component for general metadata fetching
- detect http URLs in `ExcelCell` and display previews

## Testing
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68814426637c8333bfd1f39b7bbaebd1