### PR TITLE
Clean up preview timers on unmount

### DIFF
--- a/src/ImagePreview.tsx
+++ b/src/ImagePreview.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { twJoin } from "tailwind-merge"
 
 interface ImagePreviewProps {
@@ -11,11 +11,20 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({ url, delay = 300, children 
   const [show, setShow] = useState(false)
   const [showAbove, setShowAbove] = useState(false)
   const [imageLoaded, setImageLoaded] = useState(false)
-  const timerRef = useRef<number | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const containerRef = useRef<HTMLSpanElement>(null)
 
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [delay])
+
   const handleMouseEnter = () => {
-    timerRef.current = window.setTimeout(() => {
+    timerRef.current = setTimeout(() => {
       if (containerRef.current) {
         const rect = containerRef.current.getBoundingClientRect()
         setShowAbove(rect.top > window.innerHeight / 2)

--- a/src/LinkPreview.tsx
+++ b/src/LinkPreview.tsx
@@ -35,7 +35,7 @@ const LinkPreview: React.FC<LinkPreviewProps> = ({ url, delay = 300, children })
   const [showAbove, setShowAbove] = useState(false)
   const [metadata, setMetadata] = useState<Metadata | null>(null)
   const [loading, setLoading] = useState(false)
-  const timerRef = useRef<number | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const containerRef = useRef<HTMLSpanElement>(null)
 
   const loadMetadata = useCallback(async () => {
@@ -60,8 +60,17 @@ const LinkPreview: React.FC<LinkPreviewProps> = ({ url, delay = 300, children })
     }
   }, [show, metadata, loading, loadMetadata])
 
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [delay])
+
   const handleMouseEnter = () => {
-    timerRef.current = window.setTimeout(() => {
+    timerRef.current = setTimeout(() => {
       if (containerRef.current) {
         const rect = containerRef.current.getBoundingClientRect()
         setShowAbove(rect.top > window.innerHeight / 2)


### PR DESCRIPTION
## Summary
- clear preview timeouts on unmount or delay change
- type preview timers for cross-platform compatibility

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68978718f6408333a8f14eaa065a204b