### PR TITLE
refactor: memoize sheet stats

### DIFF
--- a/src/utils/sheetStats.ts
+++ b/src/utils/sheetStats.ts
@@ -1,0 +1,27 @@
+import type { PartialCellObj } from "../types"
+
+export const getLastNonEmptyRow = (data: PartialCellObj[][]): number => {
+  let lastRowIdx = data.length
+  while (lastRowIdx > 0) {
+    const row = data[lastRowIdx - 1] || []
+    const hasData = row.some(
+      (c) => c && (c.f || (c.v !== undefined && c.v !== "")),
+    )
+    if (hasData) break
+    lastRowIdx--
+  }
+  return lastRowIdx
+}
+
+export const getLastNonEmptyCol = (data: PartialCellObj[][]): number => {
+  let lastColIdx = data.reduce((max, row) => Math.max(max, row.length), 0)
+  while (lastColIdx > 0) {
+    const hasData = data.some((row) => {
+      const c = row[lastColIdx - 1]
+      return c && (c.f || (c.v !== null && c.v !== undefined && c.v !== ""))
+    })
+    if (hasData) break
+    lastColIdx--
+  }
+  return lastColIdx
+}


### PR DESCRIPTION
## Summary
- memoize sheet stats and rows to prevent redundant scanning
- expose last non-empty row and column helpers via sheetStats utility

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68978793e9a08333b6a578c197685386